### PR TITLE
Allow read-only buffers for initial conditions of cython solver

### DIFF
--- a/CyRK/cy/_cyrk.pyx
+++ b/CyRK/cy/_cyrk.pyx
@@ -90,7 +90,7 @@ cdef double dabs(double_numeric value) nogil:
 def cyrk_ode(
     diffeq,
     (double, double) t_span,
-    double_numeric[:] y0,
+    const double_numeric[:] y0,
     tuple args = tuple(),
     double rtol = 1.e-6,
     double atol = 1.e-8,


### PR DESCRIPTION
Trying to incorporate the cython solver into my project lead to an issue where fancy indexing of my initial conditions made them read-only, which the cython memoryview buffer does not like. Ultimately this is probably more of a me problem, but I figured that the `y0` array actually only needs to be readonly, and therefore could be marked as const, thereby fixing my issue and making the code just slightly more general. Hopefully it doesn't cause subtle issues elsewhere in the compilation.